### PR TITLE
Update milestone dates to be relative to creation of working group

### DIFF
--- a/draft-charter.md
+++ b/draft-charter.md
@@ -52,14 +52,14 @@ but does not intend to publish this as an RFC.
 
 ## Milestones
 
-* April 2015: Submit COSE specification as a WG item
+* WG formation date + 1 month: Submit COSE specification as a WG item
 
-* April 2015: Submit COSE constrained-appropriate algorithms as a WG
+* WG formation date + 1 month: Submit COSE constrained-appropriate algorithms as a WG
   item
 
-* June 2015: Submit COSE specification to the IESG, for publication as
+* WG formation date + 6 months: Submit COSE specification to the IESG, for publication as
   a Proposed Standard
 
-* July 2015: Submit COSE constrained-appropriate algorithms to the
+* WG formation date + 6 months: Submit COSE constrained-appropriate algorithms to the
   IESG, for publication as a Proposed Standard
 


### PR DESCRIPTION
Since we don't know when we are starting, let's make the dates relative and the AD can resolve them to specific months when the WG gets formed.
